### PR TITLE
Remove explicit dependence on libome code to remove complexity

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "libome-fork"]
-	path = libome-fork
-	url = https://gitlab.com/hoppet-code/libome-fork.git/

--- a/libome-stub-c.c
+++ b/libome-stub-c.c
@@ -1,0 +1,10 @@
+#include <stdio.h>
+
+double ome_AqqQNSEven_reg_coeff_as(int order_as, double LM, double NF, double x)
+{
+  // Debug: print incoming arguments and the available range
+  printf("[debug] ome_AqqQNSEven_reg_coeff_as called: order_as=%d LM=%f NF=%f x=%f\n", order_as, LM, NF, x);
+  double val = (double)order_as + LM + NF + x;
+  printf("[debug] ome_AqqQNSEven_reg_coeff_as returning: %f\n", val);
+  return(val);
+}

--- a/libome-stub-cpp.cpp
+++ b/libome-stub-cpp.cpp
@@ -1,0 +1,13 @@
+#include <iostream>
+
+extern "C" {
+double ome_AqqQNSEven_reg_coeff_as(int order_as, double LM, double NF, double x)
+{
+  // Debug: print incoming arguments and the available range
+  std::cerr << "[debug] ome_AqqQNSEven_reg_coeff_as called: order_as=" << order_as
+            << " LM=" << LM << " NF=" << NF << " x=" << x << std::endl;
+  double val = static_cast<double>(order_as) + LM + NF + x;
+  std::cerr << "[debug] ome_AqqQNSEven_reg_coeff_as returning: " << val << std::endl;
+  return(val);
+}
+}


### PR DESCRIPTION
Remove submodule with actual libome code and replace it by stubs that do only trivial operation (i.e. adding the arguments and returning the sum). This should just make sure that there are no side effects from the more complicated C++ code in libome.
Add also a pure C version of the library stub to show that the problem persists even then.